### PR TITLE
fix: 0.2.5.4 warning flags in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,23 @@
 export SHELL=/bin/bash
+
+FLAGS = -Werror -Wall -Wpedantic -Wfatal-errors
 all: demo
 	@echo -e "\033[1;32mEnd of build.\e[0m\n"
 .PHONY: all
 
 demo: .demo.o
 	@echo -en "Building demo:  "
-	gcc .demo.o .animate.o -o demo -lncurses -pthread
+	gcc $(FLAGS) .demo.o .animate.o -o demo -lncurses -pthread
 	@echo -e "Done.\n"
 
 .animate.o: animate_src/animate.c animate_src/animate.h
 	@echo -en "Building animate.o:  "
-	gcc -c animate_src/animate.c -o .animate.o
+	gcc $(FLAGS) -c animate_src/animate.c -o .animate.o
 	@echo -e "Done."
 
 .demo.o: demo_src/demo.c .animate.o
 	@echo -en "Building demo.o:  "
-	gcc -c demo_src/demo.c -o .demo.o
+	gcc $(FLAGS) -c demo_src/demo.c -o .demo.o
 	@echo -e "Done."
 
 clean:

--- a/animate_src/animate.c
+++ b/animate_src/animate.c
@@ -67,7 +67,7 @@ void init_s4c_color_pairs(FILE* palette) {
  * @param line_len The length of line to print
  * @param startX X coord of the win to start printing to.
  */
-static void print_spriteline(WINDOW* win, char* line, int curr_line_num, int line_length, int startX) {
+void print_spriteline(WINDOW* win, char* line, int curr_line_num, int line_length, int startX) {
     for (int i = 0; i < line_length; i++) {
         char c = line[i];
         int color_index = c - 'a' + 8;
@@ -175,7 +175,7 @@ int load_sprites(char sprites[MAXFRAMES][MAXROWS][MAXCOLS], FILE* f, int rows, i
  */
 int animate_sprites(char sprites[MAXFRAMES][MAXROWS][MAXCOLS], WINDOW* w, int repetitions, int frametime, int num_frames, int frameheight, int framewidth) {
 	return animate_sprites_at_coords(sprites, w,repetitions, frametime, num_frames, frameheight, framewidth, 0, 0);
-};
+}
 
 /**
  * Takes a WINDOW pointer to print into and a string for the file passed.
@@ -296,7 +296,7 @@ void *animate_sprites_thread_at(void *args_ptr) {
 	} while ( args->stop_thread != 1);
 
     pthread_exit(NULL);
-};
+}
 
 /**
  * Takes a WINDOW pointer to print into and a string for the file passed.

--- a/animate_src/animate.h
+++ b/animate_src/animate.h
@@ -2,7 +2,7 @@
 #define S4C_ANIMATE_H
 #include <stdio.h>
 
-#define S4C_ANIMATE_VERSION "0.2.5.3"
+#define S4C_ANIMATE_VERSION "0.2.5.4"
 void s4c_printVersionToFile(FILE* f);
 void s4c_echoVersionToFile(FILE* f);
 
@@ -66,7 +66,7 @@ typedef struct animate_args {
 } animate_args;
 
 void init_s4c_color_pairs(FILE* palette_file);
-static void print_spriteline(WINDOW* win, char* line, int curr_line_num, int line_length, int startX);
+void print_spriteline(WINDOW* win, char* line, int curr_line_num, int line_length, int startX);
 int load_sprites(char sprites[MAXFRAMES][MAXROWS][MAXCOLS], FILE* file, int rows, int columns);
 int animate_sprites(char sprites[MAXFRAMES][MAXROWS][MAXCOLS], WINDOW* w, int repetitions, int frametime, int num_frames, int frameheight, int framewidth);
 void *animate_sprites_thread_at(void *animate_args);

--- a/demo_src/demo.c
+++ b/demo_src/demo.c
@@ -256,6 +256,8 @@ int demo(FILE* mainthread_file, FILE* newthread_file) {
 	printf("\n\t\t[Press Enter to end the demo]\n");
 	scanf("%*c");
 	system("clear");
+
+	return EXIT_SUCCESS;
 }
 
 int main(int argc, char** argv) {

--- a/documentation/s4c.doxyfile
+++ b/documentation/s4c.doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "sprites4curses"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "0.2.5.2"
+PROJECT_NUMBER         = "0.2.5.4"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a


### PR DESCRIPTION
chore: drop static keyword from print_spriteline()