### PR TITLE
0.2.6.1 - Hotfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export SHELL=/bin/bash
 
-VERSION= v0.2.6
+VERSION= v0.2.6.1
 FLAGS = -Werror -Wall -Wpedantic -Wfatal-errors
 
 all: demo

--- a/documentation/s4c.doxyfile
+++ b/documentation/s4c.doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "sprites4curses"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "0.2.6"
+PROJECT_NUMBER         = "0.2.6.1"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/s4c-animate/animate.c
+++ b/s4c-animate/animate.c
@@ -368,7 +368,7 @@ void copy_animation(char source[MAXFRAMES][MAXROWS][MAXCOLS], char dest[MAXFRAME
     //Copy all rows for frame i
     for (int j = 0 ; j < MAXROWS+1; j++) {
       //Copy all columns for row j
-     for (int k = 0 ; j < MAXCOLS+1; j++) {
+     for (int k = 0 ; k < MAXCOLS+1; k++) {
        //Assign current pixel, frame i row j col k
        dest[i][j][k] = source[i][j][k];
      }

--- a/s4c-animate/animate.h
+++ b/s4c-animate/animate.h
@@ -2,7 +2,7 @@
 #define S4C_ANIMATE_H
 #include <stdio.h>
 
-#define S4C_ANIMATE_VERSION "0.2.6"
+#define S4C_ANIMATE_VERSION "0.2.6.1"
 void s4c_printVersionToFile(FILE* f);
 void s4c_echoVersionToFile(FILE* f);
 


### PR DESCRIPTION
Fixes `copy_animation()`, which was using a bad loop condition to iterate over sprite lines.