### PR TITLE
feat: 0.2.7 test_s4c_color_pairs()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export SHELL=/bin/bash
 
-VERSION= v0.2.6.2
+VERSION= v0.2.7
 FLAGS = -Werror -Wall -Wpedantic -Wfatal-errors
 
 all: demo

--- a/documentation/s4c.doxyfile
+++ b/documentation/s4c.doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "sprites4curses"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "0.2.6.2"
+PROJECT_NUMBER         = "0.2.7"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/palette.gpl
+++ b/palette.gpl
@@ -14,7 +14,7 @@ Columns: 0
 123  66  40	LightBrown-10
  81  41  24	DarkBrown-11
  54  36 129	Purple-12
- 22  82  12 DarkGreen-13
+ 22  82  12	DarkGreen-13
  90  81  81	Grey-14
 242 245  77	LightYellow-15
  39 140 226	LightBlue-16

--- a/s4c-animate/animate.c
+++ b/s4c-animate/animate.c
@@ -61,6 +61,26 @@ void init_s4c_color_pairs(FILE* palette) {
 }
 
 /**
+ * Demoes all colors supported by the passed palette file in the passed WINDOW. Not guaranteed to work.
+ * Since it uses indexes defined by default from animate.h, it should work only when your passed palette file has color pairs for the expected index range.
+ * @param win The window to print the demo to.
+ * @param palette_file The palette file used to initialise s4c.
+ */
+void test_s4c_color_pairs(WINDOW* win, FILE* palette_file) {
+    for (int i = S4C_MIN_COLOR_INDEX; i < S4C_MAX_COLOR_INDEX +1; i++) {
+        int color_index = i;
+        if (color_index >= 0 && color_index < MAX_COLORS) {
+            wattron(win, COLOR_PAIR(color_index));
+            mvwaddch(win, 2, 2+i-S4C_MIN_COLOR_INDEX, ' ' | A_REVERSE);
+            wattroff(win, COLOR_PAIR(color_index));
+        }
+    }
+
+    wrefresh(win);
+    refresh();
+}
+
+/**
  * Takes a string and a int and prints it in curses sdtscr at the y value passed as line_num.
  * @param line The string to print
  * @param line_num The y value to print at in win

--- a/s4c-animate/animate.h
+++ b/s4c-animate/animate.h
@@ -1,25 +1,30 @@
 #ifndef S4C_ANIMATE_H
 #define S4C_ANIMATE_H
 #include <stdio.h>
-
-#define S4C_ANIMATE_VERSION "0.2.6.2"
-void s4c_printVersionToFile(FILE* f);
-void s4c_echoVersionToFile(FILE* f);
-
-#define S4C_PRINTVERSION() s4c_printVersionToFile(stdout); //Prints formatted version to stdout
-#define S4C_ECHOVERSION() s4c_echoVersionToFile(stdout); //Prints version to stdout
-
 #include <string.h>
 #include <ctype.h>
 #include <stdlib.h>
 #include <ncurses.h>
 #include <pthread.h>
 
+#define S4C_ANIMATE_VERSION "0.2.7"
+#define S4C_ANIMATE_MAJOR_VERSION 0
+#define S4C_ANIMATE_MINOR_VERSION 2
+#define S4C_ANIMATE_PATCH_VERSION 7
+
+void s4c_printVersionToFile(FILE* f);
+void s4c_echoVersionToFile(FILE* f);
+
+#define S4C_PRINTVERSION() s4c_printVersionToFile(stdout); //Prints formatted version to stdout
+#define S4C_ECHOVERSION() s4c_echoVersionToFile(stdout); //Prints version to stdout
+
+
 #define MAX_COLORS 256
 #define MAX_COLOR_NAME_LEN 256 /**< Defines max size for the name strings in palette.gpl.*/
 
 // These define constants for the colors prepared by init_s4c_color_pairs().
 #define S4C_BLACK 9
+#define S4C_MIN_COLOR_INDEX S4C_BLACK
 #define S4C_RED 10
 #define S4C_BRIGHT_GREEN 11
 #define S4C_BRIGHT_YELLOW 12
@@ -34,6 +39,7 @@ void s4c_echoVersionToFile(FILE* f);
 #define S4C_DARK_GREEN 21
 #define S4C_LIGHT_YELLOW 22
 #define S4C_LIGHT_BLUE 23
+#define S4C_MAX_COLOR_INDEX S4C_LIGHT_BLUE
 
 #define MAX_LINE_LENGTH 1024
 
@@ -66,11 +72,20 @@ typedef struct animate_args {
 } animate_args;
 
 void init_s4c_color_pairs(FILE* palette_file);
+
+void test_s4c_color_pairs(WINDOW* win, FILE* palette_file);
+
 void print_spriteline(WINDOW* win, char* line, int curr_line_num, int line_length, int startX);
+
 int load_sprites(char sprites[MAXFRAMES][MAXROWS][MAXCOLS], FILE* file, int rows, int columns);
+
 int animate_sprites(char sprites[MAXFRAMES][MAXROWS][MAXCOLS], WINDOW* w, int repetitions, int frametime, int num_frames, int frameheight, int framewidth);
+
 void *animate_sprites_thread_at(void *animate_args);
+
 int animate_sprites_at_coords(char sprites[MAXFRAMES][MAXROWS][MAXCOLS], WINDOW* w, int repetitions, int frametime, int num_frames, int frameheight, int framewidth, int startX, int startY);
+
 int animate_rangeof_sprites_at_coords(char sprites[MAXFRAMES][MAXROWS][MAXCOLS], WINDOW* w, int fromFrame, int toFrame, int repetitions, int frametime, int num_frames, int frameheight, int framewidth, int startX, int startY);
+
 void copy_animation(char source[MAXFRAMES][MAXROWS][MAXCOLS], char dest[MAXFRAMES][MAXROWS][MAXCOLS]);
 #endif

--- a/s4c-demo/demo.c
+++ b/s4c-demo/demo.c
@@ -109,6 +109,18 @@ int demo(FILE* mainthread_file, FILE* newthread_file) {
 
 	wclear(stdscr);
 	wrefresh(stdscr);
+	mvwprintw(stdscr,3,2, "Let's see a demo of the colors supported by the provided palette.gpl file:");
+	mvwprintw(stdscr,6,20, "[Press Enter to continue]");
+	wrefresh(stdscr);
+	scanf("%*c");
+	wclear(stdscr);
+	wrefresh(stdscr);
+	// Then we call the demo function with all the needed arguments
+	test_s4c_color_pairs(stdscr,palette_file);
+	napms(2000);
+
+	wclear(stdscr);
+	wrefresh(stdscr);
 	mvwprintw(stdscr,3,2, "Let's see animate_sprites:");
 	mvwprintw(stdscr,4,2, "This function puts the Upper Left animation corner at (0,0).");
 	mvwprintw(stdscr,6,20, "[Press Enter to continue]");


### PR DESCRIPTION
* adds `test_s4c_color_pairs()` and two macros to iterate over the color range from the provided `palette.gpl`.
* adds minor macros to identify current version of the lib.