### PR TITLE
fix: 0.3.5 Escape ? chars in output strings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Define the package name and version
-AC_INIT([sprites4curses], [0.3.4], [jgabaut@github.com])
+AC_INIT([sprites4curses], [0.3.5], [jgabaut@github.com])
 
 # Verify automake version and enable foreign option
 AM_INIT_AUTOMAKE([foreign -Wall])
@@ -40,7 +40,7 @@ fi
 # Set a default version number if not specified externally
 AC_ARG_VAR([VERSION], [Version number])
 if test -z "$VERSION"; then
-  VERSION="0.3.4"
+  VERSION="0.3.5"
 fi
 
 # Output variables to the config.h header

--- a/demofile.txt
+++ b/demofile.txt
@@ -1,4 +1,4 @@
-0.2.1
+0.2.2
 char chest_animation[31][18][18] = {
 
 	//Frame 1

--- a/documentation/s4c.doxyfile
+++ b/documentation/s4c.doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "sprites4curses"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "0.3.4"
+PROJECT_NUMBER         = "0.3.5"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/s4c-animate/animate.c
+++ b/s4c-animate/animate.c
@@ -1,3 +1,21 @@
+// jgabaut @ github.com/jgabaut
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+    Copyright (C) 2023  jgabaut
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, version 3 of the License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include "animate.h"
 
 /**
@@ -53,7 +71,7 @@ void debug_s4c_color(S4C_Color* color) {
 void init_s4c_color_pair(S4C_Color* color, int color_index) {
 
 	if (color == NULL) {
-		fprintf(stderr,"Error: invalid S4C_Color at in init_s4c_color_pair().");
+		fprintf(stderr,"Error: invalid S4C_Color at %s().",__func__);
 		exit(EXIT_FAILURE);
 	}
 
@@ -282,6 +300,7 @@ void s4c_print_spriteline(WINDOW* win, char* line, int curr_line_num, int line_l
  * @param columns The number of columns in each sprite.
  * @see S4C_ERR_FILEVERSION
  * @see S4C_ERR_LOADSPRITES
+ * @see S4C_FILEFORMAT_VERSION
  * @return A negative error value if loading fails or the number of sprites read.
  */
 int s4c_load_sprites(char sprites[][MAXROWS][MAXCOLS], FILE* f, int frames, int rows, int columns) {
@@ -293,7 +312,7 @@ int s4c_load_sprites(char sprites[][MAXROWS][MAXCOLS], FILE* f, int frames, int 
     char line[1024];
     char* file_version;
     char* token;
-    char* READER_VERSION = "0.2.1";
+    const char* READER_VERSION = S4C_FILEFORMAT_VERSION;
     int row = 0, frame = -1;
 
     int check = -1;

--- a/s4c-animate/animate.h
+++ b/s4c-animate/animate.h
@@ -1,3 +1,21 @@
+// jgabaut @ github.com/jgabaut
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+    Copyright (C) 2023  jgabaut
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, version 3 of the License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef S4C_ANIMATE_H
 #define S4C_ANIMATE_H
 #include <stdio.h>
@@ -13,10 +31,15 @@
 #include <pthread.h>
 
 
-#define S4C_ANIMATE_VERSION "0.3.4"
+#define S4C_ANIMATE_VERSION "0.3.5"
 #define S4C_ANIMATE_MAJOR_VERSION 0
 #define S4C_ANIMATE_MINOR_VERSION 3
-#define S4C_ANIMATE_PATCH_VERSION 4
+#define S4C_ANIMATE_PATCH_VERSION 5
+
+/**
+ * Defines current version for s4c files.
+ */
+#define S4C_FILEFORMAT_VERSION "0.2.2"
 
 void s4c_printVersionToFile(FILE* f);
 void s4c_echoVersionToFile(FILE* f);

--- a/s4c-demo/demo.c
+++ b/s4c-demo/demo.c
@@ -1,3 +1,21 @@
+// jgabaut @ github.com/jgabaut
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+    Copyright (C) 2023  jgabaut
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, version 3 of the License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include <unistd.h>
 #include <stdlib.h>
 #include <locale.h>

--- a/scripts/sheet_converter.py
+++ b/scripts/sheet_converter.py
@@ -35,7 +35,7 @@
 #
 # @section author_spritesheet Author(s)
 # - Created by jgabaut on 24/02/2023.
-# - Modified by jgabaut on 20/09/2023.
+# - Modified by jgabaut on 13/11/2023.
 
 # Imports
 from PIL import Image
@@ -44,7 +44,7 @@ import os
 import math
 
 ## The file format version.
-FILE_VERSION = "0.2.0"
+FILE_VERSION = "0.2.2"
 
 # Functions
 def usage():
@@ -100,10 +100,10 @@ def convert_spritesheet(mode, filename, spriteSizeX, spriteSizeY, separatorSize,
     char_index = 0
     for color in rgb_palette:
         if color not in CHAR_MAP:
-            CHAR_MAP[color] = chr(
-                    ord('1')
-                    + char_index
-                    )
+            if chr(ord('1') + char_index) == '?':
+                CHAR_MAP[color] = '\\?'
+            else:
+                CHAR_MAP[color] = chr(ord('1') + char_index)
             char_index += 1
 
     #for i in range(height // (sprite_size[1] + separator_size * (sprites_per_column - 1))):

--- a/scripts/sprites.py
+++ b/scripts/sprites.py
@@ -32,7 +32,7 @@
 #
 # @section author_sprites Author(s)
 # - Created by jgabaut on 24/02/2023.
-# - Modified by jgabaut on 20/09/2023.
+# - Modified by jgabaut on 13/11/2023.
 
 # Imports
 from PIL import Image
@@ -43,7 +43,7 @@ import os
 import math
 
 ## The file format version.
-FILE_VERSION = "0.2.1"
+FILE_VERSION = "0.2.2"
 
 # Expects the sprite directory name as first argument.
 # File names format inside the directory should be "imageNUM.png".
@@ -94,10 +94,10 @@ def convert_sprite(file):
     char_index = 0
     for color in rgb_palette:
         if color not in CHAR_MAP:
-            CHAR_MAP[color] = chr(
-                    ord('1')
-                    + char_index
-                    )
+            if chr(ord('1') + char_index) == '?':
+                CHAR_MAP[color] = '\\?'
+            else:
+                CHAR_MAP[color] = chr(ord('1') + char_index)
             char_index += 1
 
     # Convert each pixel to its corresponding character representation


### PR DESCRIPTION
- Update scripts to escape all `?` chars for generated files.
- Should solve trigraph problems with build using `--std=c(<23)`
- Add `S4C_FILEFORMAT_VERSION` to define expected file encoding version, and bumps it to `0.2.2`.