### PR TITLE
feat: 0.3.6 improve configure.ac, use _WIN32 in header guard

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,46 +1,56 @@
 # Define the package name and version
-AC_INIT([sprites4curses], [0.3.5], [jgabaut@github.com])
+AC_INIT([sprites4curses], [0.3.6], [jgabaut@github.com])
 
 # Verify automake version and enable foreign option
 AM_INIT_AUTOMAKE([foreign -Wall])
 
 # Detect the host system and set PACK_PREFIX accordingly
 AC_CANONICAL_HOST
+build_linux=no
+build_windows=no
+build_mac=no
 echo "Host os:  $host_os"
-AM_CONDITIONAL([OS_DARWIN], [test "$host_os" = "darwin"])
-AM_CONDITIONAL([MINGW32_BUILD], [test "$host_os" = "mingw32"])
 
 # Define the include and library paths based on the host system
-if test "$host_os" = "mingw32"; then
-  echo "Building for mingw32: [$host_cpu-$host_vendor-$host_os]"
-  # mingw32 specific flags
-  AC_SUBST([S4C_CFLAGS], ["-I/usr/x86_64-w64-mingw32/include -static -fstack-protector -DMINGW32_BUILD -DNCURSES_STATIC"])
-  AC_SUBST([S4C_LDFLAGS], ["-L/usr/x86_64-w64-mingw32/lib -lncursesw"])
-  AC_SUBST([CCOMP], ["/usr/bin/x86_64-w64-mingw32-gcc"])
-  AC_SUBST([OS], ["w64-mingw32"])
-  AC_SUBST([TARGET], ["demo.exe"])
-fi
-if test "$host_os" = "darwin"; then
-  echo "Building for macos: [$host_cpu-$host_vendor-$host_os]"
-  # macOS specific flags
-  AC_SUBST([S4C_CFLAGS], ["-I/opt/homebrew/opt/ncurses/include"])
-  AC_SUBST([S4C_LDFLAGS], ["-L/opt/homebrew/opt/ncurses/lib -lncurses"])
-  AC_SUBST([OS], ["darwin"])
-  AC_SUBST([TARGET], ["demo"])
-fi
-if test "$host_os" = "linux-gnu"; then
-  echo "Building for Linux: [$host_cpu-$host_vendor-$host_os]"
-  # Linux specific flags
-  AC_SUBST([S4C_CFLAGS], [""])
-  AC_SUBST([S4C_LDFLAGS], ["-lncurses"])
-  AC_SUBST([OS], ["Linux"])
-  AC_SUBST([TARGET], ["demo"])
-fi
+case "${host_os}" in
+    mingw*)
+        echo "Building for mingw: [$host_cpu-$host_vendor-$host_os]"
+        build_windows=yes
+        # mingw32 specific flags
+        AC_SUBST([S4C_CFLAGS], ["-I/usr/x86_64-w64-mingw32/include -static -fstack-protector -DNCURSES_STATIC"])
+        AC_SUBST([S4C_LDFLAGS], ["-L/usr/x86_64-w64-mingw32/lib -lncursesw"])
+        AC_SUBST([CCOMP], ["/usr/bin/x86_64-w64-mingw32-gcc"])
+        AC_SUBST([OS], ["w64-mingw32"])
+        AC_SUBST([TARGET], ["demo.exe"])
+    ;;
+    darwin*)
+        echo "Building for macos: [$host_cpu-$host_vendor-$host_os]"
+        build_mac=yes
+        # macOS specific flags
+        AC_SUBST([S4C_CFLAGS], ["-I/opt/homebrew/opt/ncurses/include"])
+        AC_SUBST([S4C_LDFLAGS], ["-L/opt/homebrew/opt/ncurses/lib -lncurses"])
+        AC_SUBST([OS], ["darwin"])
+        AC_SUBST([TARGET], ["demo"])
+    ;;
+    linux*)
+        echo "Building for Linux: [$host_cpu-$host_vendor-$host_os]"
+        build_linux=yes
+        # Linux specific flags
+        AC_SUBST([S4C_CFLAGS], [""])
+        AC_SUBST([S4C_LDFLAGS], ["-lncurses"])
+        AC_SUBST([OS], ["Linux"])
+        AC_SUBST([TARGET], ["demo"])
+    ;;
+esac
+
+AM_CONDITIONAL([DARWIN_BUILD], [test "$build_mac" = "yes"])
+AM_CONDITIONAL([WINDOWS_BUILD], [test "$build_windows" = "yes"])
+AM_CONDITIONAL([LINUX_BUILD], [test "$build_linux" = "yes"])
 
 # Set a default version number if not specified externally
 AC_ARG_VAR([VERSION], [Version number])
 if test -z "$VERSION"; then
-  VERSION="0.3.5"
+  VERSION="0.3.6"
 fi
 
 # Output variables to the config.h header

--- a/documentation/s4c.doxyfile
+++ b/documentation/s4c.doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "sprites4curses"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "0.3.5"
+PROJECT_NUMBER         = "0.3.6"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/s4c-animate/animate.c
+++ b/s4c-animate/animate.c
@@ -515,7 +515,7 @@ void *s4c_animate_sprites_thread_at(void *args_ptr) {
     pthread_exit(NULL);
     //FIXME
     //Is this a bug? Do we have to return NULL here?
-    #ifdef MINGW32_BUILD
+    #ifdef _WIN32
     return NULL;
     #endif
 }

--- a/s4c-animate/animate.h
+++ b/s4c-animate/animate.h
@@ -23,7 +23,7 @@
 #include <ctype.h>
 #include <stdlib.h>
 
-#ifndef MINGW32_BUILD
+#ifndef _WIN32
 #include <ncurses.h>
 #else
 #include <ncursesw/ncurses.h>
@@ -31,10 +31,10 @@
 #include <pthread.h>
 
 
-#define S4C_ANIMATE_VERSION "0.3.5"
+#define S4C_ANIMATE_VERSION "0.3.6"
 #define S4C_ANIMATE_MAJOR_VERSION 0
 #define S4C_ANIMATE_MINOR_VERSION 3
-#define S4C_ANIMATE_PATCH_VERSION 5
+#define S4C_ANIMATE_PATCH_VERSION 6
 
 /**
  * Defines current version for s4c files.


### PR DESCRIPTION
feat: refactor `MINGW32_BUILD` to `_WIN32` in `animate.h`

feat: refactor `MINGW32_BUILD` to `WINDOWS_BUILD` for build chain