### PR TITLE
feat: 0.5.2 Bump deps

### DIFF
--- a/.github/workflows/gen-demofile.yml
+++ b/.github/workflows/gen-demofile.yml
@@ -16,7 +16,7 @@ jobs:
 
     name: Generate ./demofile.txt
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
           submodules: recursive

--- a/.github/workflows/make_doc.yml
+++ b/.github/workflows/make_doc.yml
@@ -18,7 +18,7 @@ jobs:
 
     name: Generate ./documentation/docs.pdf
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/makefile-raylib.yml
+++ b/.github/workflows/makefile-raylib.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Prep raylib
       run: |
         cd src && make PLATFORM=PLATFORM_DESKTOP && sudo make install
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
     - name: Run aclocal

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
     - name: Run aclocal

--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -14,7 +14,7 @@ jobs:
 
     name: Generate ./demofile.txt
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/tex2pdf.yml
+++ b/.github/workflows/tex2pdf.yml
@@ -18,7 +18,7 @@ jobs:
 
     name: (doxygen ./documentation/s4c.doxyfile) ->    (cd ./doxygen/latex && make) ->    docs.pdf
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,11 @@ demo_gui.exe
 demo_gui_debug.exe
 # ignore gui debug executable
 demo_gui_debug
+# ignore cap test
+s4c_cap_test
+# ignore win cap test
+s4c_cap_test.exe
+
 # ignore doxygen directory
 doxygen
 # ignore docs file

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,8 @@ demo_animate_SOURCES = src/s4c.c src/palette.c s4c-demo/demo_animate.c
 
 demo_gui_SOURCES = src/s4c.c s4c-demo/demo_gui.c
 
+cap_test_SOURCES = src/s4c.c s4c-demo/cap.c
+
 # Lib source files
 lib_SOURCES = src/s4c.c
 
@@ -93,6 +95,11 @@ src/palette.c:
 	python -m s4c-scripts.s4c.core.palette C-impl $(PALETTE_PATH) ../.. > src/palette.c
 	@echo -e "Done."
 
+$(CAP_TEST_TARGET): $(cap_test_SOURCES:.c=.o)
+	@echo -e "    \033[1;35mAM_CFLAGS\e[0m: [ \"\033[1;34m$(AM_CFLAGS)\e[0m\" ]"
+	@echo -e "    \033[1;35mLDADD\e[0m: [ \"\033[1;34m$(LDADD)\e[0m\" ]"
+	$(CCOMP) -D_GNU_SOURCE $(CFLAGS) $(AM_CFLAGS) $(cap_test_SOURCES:.c=.o) -o $@ $(LDADD) $(AM_LDFLAGS) -lncursesw
+
 doc:
 	@echo -e "Using doxygen to create tex + html from $(VERSION) src/:    "
 	doxygen ./documentation/s4c.doxyfile
@@ -124,6 +131,7 @@ clean:
 	-rm $(TARGET)
 	-rm $(ANIMATE_TARGET)
 	-rm $(GUI_TARGET)
+	-rm $(CAP_TEST_TARGET)
 	-rm src/*.o
 	-rm s4c-animate/*.o
 	-rm src/palette.h

--- a/configure.ac
+++ b/configure.ac
@@ -42,12 +42,13 @@ case "${host_os}" in
             AC_SUBST([S4C_LDFLAGS], ["-L/usr/x86_64-w64-mingw32/lib -lraylib -lm -lgdi32 -lwinmm"])
         else
             AC_SUBST([S4C_CFLAGS], ["-I/usr/x86_64-w64-mingw32/include -static -fstack-protector -DNCURSES_STATIC"])
-            AC_SUBST([S4C_LDFLAGS], ["-L/usr/x86_64-w64-mingw32/lib -lmenu -lncursesw -lm"])
+            AC_SUBST([S4C_LDFLAGS], ["-L/usr/x86_64-w64-mingw32/lib -lmenuw -lncursesw -lm"])
         fi
         AC_SUBST([OS], ["w64-mingw32"])
         AC_SUBST([TARGET], ["demo.exe"])
         AC_SUBST([ANIMATE_TARGET], ["demo_animate.exe"])
         AC_SUBST([GUI_TARGET], ["demo_gui.exe"])
+        AC_SUBST([CAP_TEST_TARGET], ["s4c_cap_test.exe"])
         AC_SUBST([SHARED_LIB], ["libs4c.dll"])
     ;;
     darwin*)
@@ -66,6 +67,7 @@ case "${host_os}" in
         AC_SUBST([TARGET], ["demo"])
         AC_SUBST([ANIMATE_TARGET], ["demo_animate"])
         AC_SUBST([GUI_TARGET], ["demo_gui"])
+        AC_SUBST([CAP_TEST_TARGET], ["s4c_cap_test"])
         AC_SUBST([SHARED_LIB], ["libs4c.so"])
     ;;
     linux*)
@@ -84,6 +86,7 @@ case "${host_os}" in
         AC_SUBST([TARGET], ["demo"])
         AC_SUBST([ANIMATE_TARGET], ["demo_animate"])
         AC_SUBST([GUI_TARGET], ["demo_gui"])
+        AC_SUBST([CAP_TEST_TARGET], ["s4c_cap_test"])
         AC_SUBST([SHARED_LIB], ["libs4c.so"])
     ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Define the package name and version
-AC_INIT([sprites4curses], [0.5.1], [jgabaut@github.com])
+AC_INIT([sprites4curses], [0.5.2], [jgabaut@github.com])
 
 # Verify automake version and enable foreign option
 AM_INIT_AUTOMAKE([foreign -Wall])
@@ -98,7 +98,7 @@ AM_CONDITIONAL([LINUX_BUILD], [test "$build_linux" = "yes"])
 # Set a default version number if not specified externally
 AC_ARG_VAR([VERSION], [Version number])
 if test -z "$VERSION"; then
-  VERSION="0.5.1"
+  VERSION="0.5.2"
 fi
 
 # Output variables to the config.h header

--- a/s4c-demo/cap.c
+++ b/s4c-demo/cap.c
@@ -1,0 +1,42 @@
+#include "../src/s4c.h"
+
+int main(int argc, char** argv)
+{
+    printf("Using s4c v%s\n", string_s4c_version());
+
+    setlocale(LC_ALL, "");
+    initscr();
+    clear();
+    refresh();
+    start_color();
+
+    int curses_COLORS = COLORS;
+
+    int res = s4c_check_term();
+    switch (res) {
+        case S4C_ERR_TERMCOLOR: {
+            fprintf(stderr, "Terminal does not support color\n");
+        }
+        break;
+        case S4C_ERR_TERMCHANGECOLOR: {
+            fprintf(stderr, "Terminal does not support changing colors\n");
+        }
+        break;
+        default: {
+            fprintf(stderr, "Unknown result for s4c_check_term(): (%i)\n", res);
+        }
+        break;
+    }
+
+    mvwprintw(stdscr, 1, 1, "\x1b[38;2;120;200;255mcustom rgb\x1b[0m");
+    printw("\x1b[38;2;255;0;0mRed text\x1b[0m");
+    refresh();
+
+    wgetch(stdscr);
+
+    endwin();
+
+    printf("curses COLORS: %i\n", curses_COLORS);
+
+    return 0;
+}

--- a/src/s4c.c
+++ b/src/s4c.c
@@ -576,8 +576,8 @@ void slideshow_s4c_color_pairs(WINDOW* win)
         switch(c) {
         case 'q': { /*Enter*/
             quit = 1;
-
         };
+        break;
         case 10: { /*Enter*/
             picked = 1;
         };

--- a/src/s4c.c
+++ b/src/s4c.c
@@ -21,7 +21,7 @@
  * Returns the constant int representing current version for s4c.
  * @return A constant int in numeric format for current s4c version.
  */
-const int int_s4c_version(void)
+int int_s4c_version(void)
 {
     return S4C_API_VERSION_INT;
 }
@@ -165,7 +165,7 @@ void s4c_animate_echoVersionToFile(FILE* f)
  * Returns the constant int representing current version for s4c-animate.
  * @return A constant int in numeric format for current s4c-animate version.
  */
-const int int_s4c_animate_version(void)
+int int_s4c_animate_version(void)
 {
     return S4C_ANIMATE_API_VERSION_INT;
 }

--- a/src/s4c.h
+++ b/src/s4c.h
@@ -21,10 +21,10 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-#define S4C_VERSION "0.5.1"
+#define S4C_VERSION "0.5.2"
 #define S4C_MAJOR_VERSION 0
 #define S4C_MINOR_VERSION 5
-#define S4C_PATCH_VERSION 1
+#define S4C_PATCH_VERSION 2
 
 /**
  * Defines current API version number from S4C_{MAJOR,MINOR,PATCH}.
@@ -70,10 +70,10 @@ void s4c_dbg_features(void);
 #endif // S4C_RAYLIB_EXTENSION
 
 
-#define S4C_ANIMATE_VERSION "0.5.0"
+#define S4C_ANIMATE_VERSION "0.5.1"
 #define S4C_ANIMATE_MAJOR_VERSION 0
 #define S4C_ANIMATE_MINOR_VERSION 5
-#define S4C_ANIMATE_PATCH_VERSION 0
+#define S4C_ANIMATE_PATCH_VERSION 1
 
 /**
  * Defines current API version number from S4C_ANIMATE_{MAJOR,MINOR,PATCH}.

--- a/src/s4c.h
+++ b/src/s4c.h
@@ -36,7 +36,7 @@ static const int S4C_API_VERSION_INT =
 /**
 * Returns current s4c version as an integer.
 */
-const int int_s4c_version(void);
+int int_s4c_version(void);
 
 /**
  * Returns current s4c version as a string.
@@ -96,7 +96,7 @@ void s4c_animate_echoVersionToFile(FILE* f);
 /**
  * Returns current s4c-animate version as an integer.
  */
-const int int_s4c_animate_version(void);
+int int_s4c_animate_version(void);
 
 /**
  * Returns current s4c-animate version as a string.


### PR DESCRIPTION
### Added

- Add `s4c_cap_test`

### Changed

- Fix missing `break` in `slideshow_s4c_color_pairs()`
  - Closes #111 
- Avoid `const int` return type
- Bump `s4c-scripts` to `0.2.3`